### PR TITLE
When copying to a local destination, removed need for AWS creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To easily access Python and Conda commands from any command prompt, you need to 
      C:\Users\YourUsername\Miniconda3\Scripts
      ```
    - (Optional) Click **New** again and add the `watchdog3` directory to access bat scripts (some windows systems don't recognize *.bat scripts from that directory):
-     IMPORTANT: This path is hardcoded in the python script to function with Bruker systems. You can modify as needed
+     IMPORTANT: This path is defaulted in the python script to function with Bruker systems. You can modify as needed with the `--working-dir` argument
      ```
      C:\seer-scripts\watchdog3
      ```
@@ -81,34 +81,32 @@ Place the ```seer_watchdog.py``` and ```seer_watchdog.bat``` scripts in the foll
 ### Basic Command Structure
 
 ```shell
-python seer_watchdog.py --source <SOURCE> --dest <DESTINATION_PATH> --instrument <INSTRUMENT_TYPE> --destination <DESTINATION_TYPE> [--bucket <BUCKET_NAME>] [--aws_access_key_id <ACCESS_KEY>] [--aws_secret_access_key <SECRET_KEY>] [--log_group <LOG_GROUP>] [--log_stream <LOG_STREAM>]
+usage: seer_watchdog.py [-h] [--aws_access_key_id AWS_ACCESS_KEY_ID] [--aws_secret_access_key AWS_SECRET_ACCESS_KEY] [--aws-region AWS_REGION] --source SOURCE [--bucket BUCKET] [--dest DEST] --instrument {Bruker,Thermo,Sciex} --destination {S3,Directory} [--log_group LOG_GROUP] [--log_stream LOG_STREAM] [--working-dir WORKING_DIR]
 
-usage: seer_watchdog.py [-h] [--aws_access_key_id AWS_ACCESS_KEY_ID]
-                        [--aws_secret_access_key AWS_SECRET_ACCESS_KEY]
-                        --source SOURCE [--bucket BUCKET] [--dest DEST]
-                        --instrument {Bruker,Thermo,Sciex} --destination
-                        {S3,Directory} [--log_group LOG_GROUP]
-                        [--log_stream LOG_STREAM]
+Zip Bruker and Sciex *.wiff and *.d directories (or transfer Thermo *.raw), upload it to AWS S3 or copy it to a local directory based on the instrument type and destination, verify integrity, and log both locally and to CloudWatch (if configured).
 
-Zip Bruker and Sciex *.wiff and *.d directories (or transfer Thermo *.raw),
-upload it to AWS S3 or copy it to a local directory based on the instrument
-type and destination, verify integrity, and log both locally and to
-CloudWatch.
-
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --aws_access_key_id AWS_ACCESS_KEY_ID
                         AWS access key ID (required only if destination is S3)
   --aws_secret_access_key AWS_SECRET_ACCESS_KEY
                         AWS secret access key (required only if destination is S3)
+  --aws-region AWS_REGION
+                        AWS region (required only if destination is S3)
   --source SOURCE       Source directory or file to be uploaded/copied
   --bucket BUCKET       Destination S3 bucket name (required only if destination is S3)
   --dest DEST           Destination directory for file copy (required only if destination is Directory)
-  --instrument {Bruker,Thermo,Sciex} Type of instrument
-  --destination {S3,Directory} Destination type: Upload to S3 or copy to a local directory
-  --log_group LOG_GROUP CloudWatch Logs group name (required only if destination is S3)
-  --log_stream LOG_STREAM CloudWatch Logs stream name (required only if destination is S3)
-  --install-dir Installation directory path (required)
+  --instrument {Bruker,Thermo,Sciex}
+                        Type of instrument
+  --destination {S3,Directory}
+                        Destination type: Upload to S3 or copy to a local directory
+  --log_group LOG_GROUP
+                        CloudWatch Logs group name (required only if destination is S3)
+  --log_stream LOG_STREAM
+                        CloudWatch Logs stream name (required only if destination is S3)
+  --working-dir WORKING_DIR
+                        Working directory for log files etc (optional, defaults to C:/seer-scripts/watchdog3)
+
 ```
 
 

--- a/seer_watchdog.py
+++ b/seer_watchdog.py
@@ -20,6 +20,9 @@ def setup_cloudwatch_logs(cw_client, log_group_name, log_stream_name):
 
 def log_to_cloudwatch(cw_client, log_group_name, log_stream_name, message):
     """Logs a message to CloudWatch Logs."""
+    if cw_client is None:
+        return  # CloudWatch client not initialized
+    
     response = cw_client.describe_log_streams(logGroupName=log_group_name, logStreamNamePrefix=log_stream_name)
     upload_sequence_token = response['logStreams'][0].get('uploadSequenceToken', '0')
 
@@ -109,54 +112,56 @@ def find_or_create_prefixed_dir(dest, prefix):
 
 def main(args):
     global cw_client  # To make cw_client accessible in other functions
+    cw_client = None  # Initialize CloudWatch client to None for local logging only
 
     # Change the working directory to the specified source directory
-    os.chdir('C:/seer-scripts/watchdog3')
+    os.chdir(args.working_dir)
 
-    try:
-        s3_client = boto3.client('s3', aws_access_key_id=args.aws_access_key_id,
-                                 aws_secret_access_key=args.aws_secret_access_key,
-                                 region_name=args.aws_region)
-        cw_client = boto3.client('logs', aws_access_key_id=args.aws_access_key_id,
-                                 aws_secret_access_key=args.aws_secret_access_key,
-                                 region_name=args.aws_region)
-        setup_cloudwatch_logs(cw_client, args.log_group, args.log_stream)
+    if args.destination == 'S3':
+        try:
+            s3_client = boto3.client('s3', aws_access_key_id=args.aws_access_key_id,
+                                    aws_secret_access_key=args.aws_secret_access_key,
+                                    region_name=args.aws_region)
+            cw_client = boto3.client('logs', aws_access_key_id=args.aws_access_key_id,
+                                    aws_secret_access_key=args.aws_secret_access_key,
+                                    region_name=args.aws_region)
+            setup_cloudwatch_logs(cw_client, args.log_group, args.log_stream)
+        except NoCredentialsError:
+            message = "No AWS credentials found. Please configure your AWS credentials."
+            log_locally(message)
+        except PartialCredentialsError:
+            message = "Incomplete AWS credentials. Please check your AWS access key ID and secret access key."
+            log_locally(message)
 
-        file_to_transfer = args.source
-        if args.instrument in ['Bruker', 'Sciex']:
-            file_to_transfer = zip_directory(args.source, os.path.basename(args.source))
-            file_name = os.path.basename(file_to_transfer)
-            original_checksum = calculate_checksum(file_to_transfer)
-            if args.destination == 'S3':
-                upload_file_to_s3(s3_client, file_to_transfer, args.bucket, file_name)
-            elif args.destination == 'Directory':
-                copy_file_to_directory(file_to_transfer, args.dest, file_name)
-            os.remove(file_to_transfer)  # Delete the zip file after use
-            log_message = f"Deleted local zip file {file_to_transfer}"
-            log_locally(log_message)
-            log_to_cloudwatch(cw_client, args.log_group, args.log_stream, log_message)
-        else:
-            file_name = os.path.basename(file_to_transfer)
-            if args.destination == 'S3':
-                upload_file_to_s3(s3_client, file_to_transfer, args.bucket, file_name)
-            elif args.destination == 'Directory':
-                copy_file_to_directory(file_to_transfer, args.dest, file_name)
+    file_to_transfer = args.source
+
+    if args.instrument in ['Bruker', 'Sciex']:
+        file_to_transfer = zip_directory(args.source, os.path.basename(args.source))
+        file_name = os.path.basename(file_to_transfer)
+        if args.destination == 'S3':
+            upload_file_to_s3(s3_client, file_to_transfer, args.bucket, file_name)
+        elif args.destination == 'Directory':
+            copy_file_to_directory(file_to_transfer, args.dest, file_name)
+
+        os.remove(file_to_transfer)  # Delete the zip file after use
+        log_message = f"Deleted local zip file {file_to_transfer}"
+        log_locally(log_message)
+        log_to_cloudwatch(cw_client, args.log_group, args.log_stream, log_message)
+
+    else:
+        file_name = os.path.basename(file_to_transfer)
+        if args.destination == 'S3':
+            upload_file_to_s3(s3_client, file_to_transfer, args.bucket, file_name)
+        elif args.destination == 'Directory':
+            copy_file_to_directory(file_to_transfer, args.dest, file_name)
 
 
-    except NoCredentialsError:
-        message = "No AWS credentials found. Please configure your AWS credentials."
-        log_locally(message)
-        log_to_cloudwatch(cw_client, args.log_group, args.log_stream, message)
-    except PartialCredentialsError:
-        message = "Incomplete AWS credentials. Please check your AWS access key ID and secret access key."
-        log_locally(message)
-        log_to_cloudwatch(cw_client, args.log_group, args.log_stream, message)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Zip Bruker and Sciex *.wiff and *.d directories (or transfer Thermo *.raw), upload it to AWS S3 or copy it to a local directory based on the instrument type and destination, verify integrity, and log both locally and to CloudWatch.')
+    parser = argparse.ArgumentParser(description='Zip Bruker and Sciex *.wiff and *.d directories (or transfer Thermo *.raw), upload it to AWS S3 or copy it to a local directory based on the instrument type and destination, verify integrity, and log both locally and to CloudWatch (if configured).')
     parser.add_argument('--aws_access_key_id', help='AWS access key ID (required only if destination is S3)', default=None)
     parser.add_argument('--aws_secret_access_key', help='AWS secret access key (required only if destination is S3)', default=None)
-    parser.add_argument('--aws-region', help='AWS region for Boto3', required=True)
+    parser.add_argument('--aws-region', help='AWS region (required only if destination is S3)', default=None)
     parser.add_argument('--source', help='Source directory or file to be uploaded/copied', required=True)
     parser.add_argument('--bucket', help='Destination S3 bucket name (required only if destination is S3)', default=None)
     parser.add_argument('--dest', help='Destination directory for file copy (required only if destination is Directory)', default=None)
@@ -164,6 +169,7 @@ if __name__ == "__main__":
     parser.add_argument('--destination', choices=['S3', 'Directory'], help='Destination type: Upload to S3 or copy to a local directory', required=True)
     parser.add_argument('--log_group', help='CloudWatch Logs group name (required only if destination is S3)', default='S3UploadLogs')
     parser.add_argument('--log_stream', help='CloudWatch Logs stream name (required only if destination is S3)', default='InstrumentUploads')
+    parser.add_argument('--working-dir', help='Working directory for log files etc (optional, defaults to C:/seer-scripts/watchdog3)', default='C:/seer-scripts/watchdog3')
 
     args = parser.parse_args()
     main(args)

--- a/seer_watchdog.py
+++ b/seer_watchdog.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import boto3
 import argparse
@@ -88,6 +89,8 @@ def copy_file_to_directory(source, dest, file_name):
         error_message = f"Error: Integrity check failed for {file_name} after copying."
         log_locally(error_message)
         log_to_cloudwatch(cw_client, args.log_group, args.log_stream, error_message)
+        import sys
+        sys.exit(1)
 
 def calculate_checksum(file_path):
     """Calculates the MD5 checksum of a file."""
@@ -129,9 +132,11 @@ def main(args):
         except NoCredentialsError:
             message = "No AWS credentials found. Please configure your AWS credentials."
             log_locally(message)
+            sys.exit(1)
         except PartialCredentialsError:
             message = "Incomplete AWS credentials. Please check your AWS access key ID and secret access key."
             log_locally(message)
+            sys.exit(1)
 
     file_to_transfer = args.source
 


### PR DESCRIPTION
This pull request updates both the `README.md` documentation and the `seer_watchdog.py` script to improve usability, clarity, and error handling for users running the watchdog tool. The main changes clarify the usage of the working directory, update the command-line interface, and enhance error handling for AWS credentials.

**Documentation and CLI improvements:**

* Updated the `README.md` to clarify that the working directory path is now configurable via the `--working-dir` argument, replacing the previous hardcoded approach. The command-line usage section now matches the actual script arguments and includes a description of the new option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R109)
* Added the `--working-dir` argument to the CLI, allowing users to specify the working directory for logs and other files, with a default value provided. The script now changes to this directory at runtime. [[1]](diffhunk://#diff-d27c99a494ff6a789fcd3ac1bb40a05ca88c04aea3e342a95394a769b98bf619R115-R120) [[2]](diffhunk://#diff-d27c99a494ff6a789fcd3ac1bb40a05ca88c04aea3e342a95394a769b98bf619L146-R172)

**Error handling and robustness:**

* Improved error handling for AWS credentials: the script now logs a clear message locally if credentials are missing or incomplete, and avoids attempting CloudWatch logging when the client is not initialized. [[1]](diffhunk://#diff-d27c99a494ff6a789fcd3ac1bb40a05ca88c04aea3e342a95394a769b98bf619R129-R150) [[2]](diffhunk://#diff-d27c99a494ff6a789fcd3ac1bb40a05ca88c04aea3e342a95394a769b98bf619R23-R25)

These changes make the script easier to configure and use, especially in different environments, and provide more helpful feedback to users in case of misconfiguration.…AWS credentials